### PR TITLE
No more `make`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please [open an issue](https://github.com/zio/zio-streams-compress/issues/new) o
 on [Discord](https://discord.com/channels/629491597070827530/630498701860929559) if you have suggestions. The API will
 stabilize in Jan 2025, followed by a 1.0.0 release.
 
-## Usage
+## Installation
 
 In order to use this library, we need to add one of the following line in our `build.sbt` file:
 
@@ -46,49 +46,49 @@ Currently only jvm is supported. PRs for scala-js and scala-native are welcome.
 // Example.sc
 // Run with: scala-cli Example.sc
 //> using dep dev.zio:zio-streams-compress-gzip:0.0.1
-//> using dep dev.zio:zio-streams-compress-zip:0.0.1
 //> using dep dev.zio:zio-streams-compress-tar:0.0.1
+//> using dep dev.zio:zio-streams-compress-zip4j:0.0.1
 
 import zio._
-import zio.compress.{ArchiveEntry, GzipCompressor, GzipDecompressor, TarUnarchiver, ZipArchiver}
+import zio.compress.{ArchiveEntry, GzipCompressor, GzipDecompressor, TarUnarchiver, Zip4JArchiver}
 import zio.stream._
 
 import java.nio.charset.StandardCharsets.UTF_8
 
 object ExampleApp extends ZIOAppDefault {
-  override def run =
+  override def run: ZIO[Any, Any, Any] =
     for {
       // Compress a file with GZIP
       _ <- ZStream
-        .fromFileName("file")
-        .via(GzipCompressor.make().compress)
-        .run(ZSink.fromFileName("file.gz"))
+             .fromFileName("file")
+             .via(GzipCompressor.compress)
+             .run(ZSink.fromFileName("file.gz"))
 
       // List all items in a gzip tar archive:
       _ <- ZStream
-        .fromFileName("file.tgz")
-        .via(GzipDecompressor.make().decompress)
-        .via(TarUnarchiver.make().unarchive)
-        .mapZIO { case (archiveEntry, contentStream) =>
-          for {
-            content <- contentStream.runCollect
-            _ <- Console.printLine(s"${archiveEntry.name} ${content.length}")
-          } yield ()
-        }
-        .runDrain
+             .fromFileName("file.tgz")
+             .via(GzipDecompressor.decompress)
+             .via(TarUnarchiver.unarchive)
+             .mapZIO { case (archiveEntry, contentStream) =>
+               for {
+                 content <- contentStream.runCollect
+                 _ <- Console.printLine(s"${archiveEntry.name} ${content.length}")
+               } yield ()
+             }
+             .runDrain
 
-      // Create a ZIP archive (use the zip4j version for password support)
+      // Create an encrypted ZIP archive
       _ <- ZStream(archiveEntry("file1.txt", "Hello world!".getBytes(UTF_8)))
-        .via(ZipArchiver.make().archive)
-        .run(ZSink.fromFileName("file.zip"))
+             .via(Zip4JArchiver(password = Some("it is a secret")).archive)
+             .run(ZSink.fromFileName("file.zip"))
     } yield ()
 
   private def archiveEntry(
-                            name: String,
-                            content: Array[Byte]
-                          ): (ArchiveEntry[Some, Any], ZStream[Any, Throwable, Byte]) = {
-    (ArchiveEntry(name, Some(content.length)), ZStream.fromIterable(content))
-  }
+    name: String,
+    content: Array[Byte],
+  ): (ArchiveEntry[Some, Any], ZStream[Any, Throwable, Byte]) =
+    (ArchiveEntry(name, Some(content.length.toLong)), ZStream.fromIterable(content))
+
 }
 ```
 

--- a/brotli/src/main/scala/zio/compress/Brotli.scala
+++ b/brotli/src/main/scala/zio/compress/Brotli.scala
@@ -28,7 +28,6 @@ object BrotliDecompressor {
 //noinspection ScalaFileName
 final class BrotliDecompressor private (customDictionary: Option[Array[Byte]], chunkSize: Int) extends Decompressor {
 
-  /** @inheritdoc */
   override def decompress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     // BrotliInputStream.read does its best to read as many bytes as requested; no buffering needed.
     viaInputStreamByte(chunkSize) { inputStream =>

--- a/brotli/src/main/scala/zio/compress/Brotli.scala
+++ b/brotli/src/main/scala/zio/compress/Brotli.scala
@@ -8,22 +8,27 @@ import zio.Trace
 //noinspection ScalaFileName
 object BrotliDecompressor {
 
-  /** Makes a pipeline that accepts a Brotli compressed byte stream and produces a decompressed byte stream.
+  /** A [[Decompressor]] for Brotli, based on the official Brotli library.
     *
     * @param customDictionary
     *   a custom dictionary, or `None` for no custom dictionary
     * @param chunkSize
     *   The maximum chunk size of the outgoing ZStream. Defaults to `ZStream.DefaultChunkSize` (4KiB).
     */
-  def make(
+  def apply(
     customDictionary: Option[Array[Byte]] = None,
     chunkSize: Int = ZStream.DefaultChunkSize,
   ): BrotliDecompressor =
     new BrotliDecompressor(customDictionary, chunkSize)
+
+  /** See [[apply]] and [[Decompressor.decompress]]. */
+  def decompress: ZPipeline[Any, Throwable, Byte, Byte] = apply().decompress
 }
 
 //noinspection ScalaFileName
 final class BrotliDecompressor private (customDictionary: Option[Array[Byte]], chunkSize: Int) extends Decompressor {
+
+  /** @inheritdoc */
   override def decompress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     // BrotliInputStream.read does its best to read as many bytes as requested; no buffering needed.
     viaInputStreamByte(chunkSize) { inputStream =>

--- a/brotli/src/test/scala/zio/compress/BrotliSpec.scala
+++ b/brotli/src/test/scala/zio/compress/BrotliSpec.scala
@@ -18,7 +18,7 @@ object BrotliSpec extends ZIOSpecDefault {
         for {
           obtained <- ZStream
                         .fromChunk(compressed)
-                        .via(BrotliDecompressor.make().decompress)
+                        .via(BrotliDecompressor.decompress)
                         .runCollect
         } yield assertTrue(clear == obtained)
       }

--- a/brotli4j/src/main/scala/zio/compress/Brotli4J.scala
+++ b/brotli4j/src/main/scala/zio/compress/Brotli4J.scala
@@ -36,7 +36,6 @@ final class Brotli4JCompressor private (
   mode: Option[BrotliMode],
 ) extends Compressor {
 
-  /** @inheritdoc */
   override def compress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     BrotliLoader.ensureAvailability() >>>
       viaOutputStreamByte { outputStream =>
@@ -71,7 +70,6 @@ object Brotli4JDecompressor {
 
 final class Brotli4JDecompressor private (chunkSize: Int) extends Decompressor {
 
-  /** @inheritdoc */
   override def decompress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     BrotliLoader.ensureAvailability() >>>
       viaInputStreamByte(chunkSize) { inputStream =>

--- a/brotli4j/src/test/scala/zio/compress/Brotli4JSpec.scala
+++ b/brotli4j/src/test/scala/zio/compress/Brotli4JSpec.scala
@@ -17,7 +17,7 @@ object Brotli4JSpec extends ZIOSpecDefault {
         for {
           obtained <- ZStream
                         .fromChunk(compressed)
-                        .via(Brotli4JDecompressor.make().decompress)
+                        .via(Brotli4JDecompressor.decompress)
                         .runCollect
         } yield assertTrue(clear == obtained)
       },
@@ -27,8 +27,8 @@ object Brotli4JSpec extends ZIOSpecDefault {
             obtained <- ZStream
                           .fromChunk(genBytes)
                           .rechunk(chunkSize)
-                          .via(Brotli4JCompressor.make().compress)
-                          .via(Brotli4JDecompressor.make().decompress)
+                          .via(Brotli4JCompressor.compress)
+                          .via(Brotli4JDecompressor.decompress)
                           .runCollect
           } yield assertTrue(obtained == genBytes)
         }

--- a/build.sbt
+++ b/build.sbt
@@ -198,7 +198,7 @@ lazy val zstd = projectMatrix
 
 lazy val example = projectMatrix
   .in(file("example"))
-  .dependsOn(gzip, tar, zip)
+  .dependsOn(gzip, tar, zip4j)
   .settings(commonSettings("example"))
   .settings(
     publishArtifact := false,

--- a/build.sbt
+++ b/build.sbt
@@ -49,15 +49,6 @@ inThisBuild(
 
 def commonSettings(projectName: String) = Seq(
   name := s"zio-streams-compress-$projectName",
-//    Compile / compile / scalacOptions ++=
-//      optionsOn("2.13")("-Wconf:cat=unused-nowarn:s").value,
-  // scalacOptions -= "-Xlint:infer-any",
-  // workaround for bad constant pool issue
-  //  (Compile / doc) := Def.taskDyn {
-  //    val default = (Compile / doc).taskValue
-  //    Def.task(default.value)
-  //  }.value,
-  //  Test / scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
   libraryDependencies ++= Seq(
     "dev.zio" %%% "zio-test" % V.zio % Test,
     "dev.zio" %%% "zio-test-sbt" % V.zio % Test,

--- a/bzip2/src/main/scala/zio/compress/Bzip2.scala
+++ b/bzip2/src/main/scala/zio/compress/Bzip2.scala
@@ -25,7 +25,6 @@ object Bzip2Compressor {
 
 final class Bzip2Compressor private (blockSize: Option[Bzip2BlockSize]) extends Compressor {
 
-  /** @inheritdoc */
   override def compress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     viaOutputStreamByte { outputStream =>
       blockSize match {
@@ -51,7 +50,6 @@ object Bzip2Decompressor {
 
 final class Bzip2Decompressor private (chunkSize: Int) extends Decompressor {
 
-  /** @inheritdoc */
   override def decompress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     // BrotliInputStream.read does its best to read as many bytes as requested; no buffering needed.
     viaInputStreamByte(chunkSize)(new BZip2CompressorInputStream(_))

--- a/bzip2/src/main/scala/zio/compress/Bzip2.scala
+++ b/bzip2/src/main/scala/zio/compress/Bzip2.scala
@@ -7,7 +7,7 @@ import zio.Trace
 
 object Bzip2Compressor {
 
-  /** Make a pipeline that accepts a stream of bytes and produces a stream with Bzip2 compressed bytes.
+  /** A [[Compressor]] for Bzip2, based on the Apache Commons Compress library.
     *
     * Note: Bzip2 uses a lot of memory. See
     * [[org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream]] for an overview of the required heap
@@ -16,11 +16,16 @@ object Bzip2Compressor {
     * @param blockSize
     *   the block size to use. Defaults to 900KB.
     */
-  def make(blockSize: Option[Bzip2BlockSize] = None): Bzip2Compressor =
+  def apply(blockSize: Option[Bzip2BlockSize] = None): Bzip2Compressor =
     new Bzip2Compressor(blockSize)
+
+  /** See [[apply]] and [[Compressor.compress]]. */
+  def compress: ZPipeline[Any, Throwable, Byte, Byte] = apply().compress
 }
 
 final class Bzip2Compressor private (blockSize: Option[Bzip2BlockSize]) extends Compressor {
+
+  /** @inheritdoc */
   override def compress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     viaOutputStreamByte { outputStream =>
       blockSize match {
@@ -32,16 +37,21 @@ final class Bzip2Compressor private (blockSize: Option[Bzip2BlockSize]) extends 
 
 object Bzip2Decompressor {
 
-  /** Makes a pipeline that accepts a Bzip2 compressed byte stream and produces a decompressed byte stream.
+  /** A [[Decompressor]] for Bzip2, based on the Apache Commons Compress library.
     *
     * @param chunkSize
     *   The maximum chunk size of the outgoing ZStream. Defaults to `ZStream.DefaultChunkSize` (4KiB).
     */
-  def make(chunkSize: Int = ZStream.DefaultChunkSize): Bzip2Decompressor =
+  def apply(chunkSize: Int = ZStream.DefaultChunkSize): Bzip2Decompressor =
     new Bzip2Decompressor(chunkSize)
+
+  /** See [[apply]] and [[Decompressor.decompress]]. */
+  def decompress: ZPipeline[Any, Throwable, Byte, Byte] = apply().decompress
 }
 
 final class Bzip2Decompressor private (chunkSize: Int) extends Decompressor {
+
+  /** @inheritdoc */
   override def decompress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     // BrotliInputStream.read does its best to read as many bytes as requested; no buffering needed.
     viaInputStreamByte(chunkSize)(new BZip2CompressorInputStream(_))

--- a/bzip2/src/test/scala/zio/compress/Bzip2Spec.scala
+++ b/bzip2/src/test/scala/zio/compress/Bzip2Spec.scala
@@ -20,7 +20,7 @@ object Bzip2Spec extends ZIOSpecDefault {
         for {
           obtained <- ZStream
                         .fromChunk(clear)
-                        .via(Bzip2Compressor.make().compress)
+                        .via(Bzip2Compressor.compress)
                         .runCollect
         } yield assertTrue(compressed == obtained)
       },
@@ -28,7 +28,7 @@ object Bzip2Spec extends ZIOSpecDefault {
         for {
           obtained <- ZStream
                         .fromChunk(compressed)
-                        .via(Bzip2Decompressor.make().decompress)
+                        .via(Bzip2Decompressor.decompress)
                         .runCollect
         } yield assertTrue(clear == obtained)
       },
@@ -38,8 +38,8 @@ object Bzip2Spec extends ZIOSpecDefault {
             obtained <- ZStream
                           .fromChunk(genBytes)
                           .rechunk(chunkSize)
-                          .via(Bzip2Compressor.make().compress)
-                          .via(Bzip2Decompressor.make().decompress)
+                          .via(Bzip2Compressor.compress)
+                          .via(Bzip2Decompressor.decompress)
                           .runCollect
           } yield assertTrue(obtained == genBytes)
         }

--- a/core/src/main/scala/zio/compress/ArchiveSingleFile.scala
+++ b/core/src/main/scala/zio/compress/ArchiveSingleFile.scala
@@ -7,6 +7,8 @@ final class ArchiveSingleFileCompressor[Size[A] <: Option[A]] private (
   archiver: Archiver[Size],
   entry: ArchiveEntry[Size, Any],
 ) extends Compressor {
+
+  /** @inheritdoc */
   override def compress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     ZPipeline.fromFunction { stream =>
       ZStream((entry, stream)).via(archiver.archive)
@@ -30,6 +32,8 @@ object ArchiveSingleFileCompressor {
 final class ArchiveSingleFileDecompressor[Size[A] <: Option[A], Underlying] private (
   unarchiver: Unarchiver[Size, Underlying]
 ) extends Decompressor {
+
+  /** @inheritdoc */
   override def decompress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     ZPipeline.fromFunction { stream =>
       stream

--- a/core/src/main/scala/zio/compress/ArchiveSingleFile.scala
+++ b/core/src/main/scala/zio/compress/ArchiveSingleFile.scala
@@ -8,7 +8,6 @@ final class ArchiveSingleFileCompressor[Size[A] <: Option[A]] private (
   entry: ArchiveEntry[Size, Any],
 ) extends Compressor {
 
-  /** @inheritdoc */
   override def compress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     ZPipeline.fromFunction { stream =>
       ZStream((entry, stream)).via(archiver.archive)
@@ -33,7 +32,6 @@ final class ArchiveSingleFileDecompressor[Size[A] <: Option[A], Underlying] priv
   unarchiver: Unarchiver[Size, Underlying]
 ) extends Decompressor {
 
-  /** @inheritdoc */
   override def decompress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     ZPipeline.fromFunction { stream =>
       stream

--- a/core/src/main/scala/zio/compress/Archiver.scala
+++ b/core/src/main/scala/zio/compress/Archiver.scala
@@ -3,7 +3,15 @@ package zio.compress
 import zio._
 import zio.stream.{ZPipeline, ZStream}
 
+/** An archiver makes pipelines that accept a stream of archive entries, and produce a byte stream of an archive.
+  *
+  * @tparam Size
+  *   Either a `Some` when the archive entries require the uncompressed size, or `Option` when the archive entries do
+  *   not require the uncompressed size.
+  */
 trait Archiver[-Size[A] <: Option[A]] extends Serializable {
+
+  /** Makes a pipeline that accepts a stream of archive entries, and produces a byte stream of an archive. */
   def archive(implicit
     trace: Trace
   ): ZPipeline[Any, Throwable, (ArchiveEntry[Size, Any], ZStream[Any, Throwable, Byte]), Byte]

--- a/core/src/main/scala/zio/compress/Compressor.scala
+++ b/core/src/main/scala/zio/compress/Compressor.scala
@@ -4,11 +4,18 @@ import zio.stream._
 import zio.Trace
 
 trait Compressor extends Serializable {
+
+  /** A pipeline that takes a raw byte stream and produces a compressed byte stream. */
   def compress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte]
 }
 
-object Compressor {
+object Compressor extends Serializable {
+
+  /** A compressor that does nothing; it passes all bytes through unchanged. */
   def empty: Compressor = new Compressor {
-    override def compress(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Byte] = ZPipeline.identity
+
+    /** @inheritdoc */
+    override def compress(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Byte] =
+      ZPipeline.identity
   }
 }

--- a/core/src/main/scala/zio/compress/Compressor.scala
+++ b/core/src/main/scala/zio/compress/Compressor.scala
@@ -14,7 +14,6 @@ object Compressor extends Serializable {
   /** A compressor that does nothing; it passes all bytes through unchanged. */
   def empty: Compressor = new Compressor {
 
-    /** @inheritdoc */
     override def compress(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Byte] =
       ZPipeline.identity
   }

--- a/core/src/main/scala/zio/compress/Decompressor.scala
+++ b/core/src/main/scala/zio/compress/Decompressor.scala
@@ -4,11 +4,18 @@ import zio.Trace
 import zio.stream._
 
 trait Decompressor extends Serializable {
+
+  /** A pipeline that decompresses a byte stream to an uncompressed byte stream. */
   def decompress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte]
 }
 
 object Decompressor {
+
+  /** A decompressor that does nothing; it passes all bytes through unchanged. */
   def empty: Decompressor = new Decompressor {
-    override def decompress(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Byte] = ZPipeline.identity
+
+    /** @inheritdoc */
+    override def decompress(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Byte] =
+      ZPipeline.identity
   }
 }

--- a/core/src/main/scala/zio/compress/Decompressor.scala
+++ b/core/src/main/scala/zio/compress/Decompressor.scala
@@ -14,7 +14,6 @@ object Decompressor {
   /** A decompressor that does nothing; it passes all bytes through unchanged. */
   def empty: Decompressor = new Decompressor {
 
-    /** @inheritdoc */
     override def decompress(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Byte] =
       ZPipeline.identity
   }

--- a/core/src/main/scala/zio/compress/Unarchiver.scala
+++ b/core/src/main/scala/zio/compress/Unarchiver.scala
@@ -3,7 +3,17 @@ package zio.compress
 import zio.Trace
 import zio.stream._
 
+/** An unarchiver makes pipelines that accept the byte stream of an archive, and produce a stream of archive entries.
+  *
+  * @tparam Size
+  *   Either a `Some` when the archive entries have a known uncompressed size, `None` when the archive entries _do not_
+  *   have the uncompressed size, or `Option` when the archive entries _might_ have the uncompressed size.
+  * @tparam Underlying
+  *   The archive entries from the underlying archiving library.
+  */
 trait Unarchiver[Size[A] <: Option[A], Underlying] extends Serializable {
+
+  /** Make a pipelines that accepts the byte stream of an archive, and produces a stream of archive entries. */
   def unarchive(implicit
     trace: Trace
   ): ZPipeline[Any, Throwable, Byte, (ArchiveEntry[Size, Underlying], ZStream[Any, Throwable, Byte])]

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Please [open an issue](https://github.com/zio/zio-streams-compress/issues/new) o
 on [Discord](https://discord.com/channels/629491597070827530/630498701860929559) if you have suggestions. The API will
 stabilize in Jan 2025, followed by a 1.0.0 release.
 
-## Usage
+## Installation
 
 In order to use this library, we need to add one of the following line in our `build.sbt` file:
 
@@ -46,49 +46,49 @@ Currently only jvm is supported. PRs for scala-js and scala-native are welcome.
 // Example.sc
 // Run with: scala-cli Example.sc
 //> using dep dev.zio:zio-streams-compress-gzip:@VERSION@
-//> using dep dev.zio:zio-streams-compress-zip:@VERSION@
 //> using dep dev.zio:zio-streams-compress-tar:@VERSION@
+//> using dep dev.zio:zio-streams-compress-zip4j:@VERSION@
 
 import zio._
-import zio.compress.{ArchiveEntry, GzipCompressor, GzipDecompressor, TarUnarchiver, ZipArchiver}
+import zio.compress.{ArchiveEntry, GzipCompressor, GzipDecompressor, TarUnarchiver, Zip4JArchiver}
 import zio.stream._
 
 import java.nio.charset.StandardCharsets.UTF_8
 
 object ExampleApp extends ZIOAppDefault {
-  override def run =
+  override def run: ZIO[Any, Any, Any] =
     for {
       // Compress a file with GZIP
       _ <- ZStream
-        .fromFileName("file")
-        .via(GzipCompressor.make().compress)
-        .run(ZSink.fromFileName("file.gz"))
+             .fromFileName("file")
+             .via(GzipCompressor.compress)
+             .run(ZSink.fromFileName("file.gz"))
 
       // List all items in a gzip tar archive:
       _ <- ZStream
-        .fromFileName("file.tgz")
-        .via(GzipDecompressor.make().decompress)
-        .via(TarUnarchiver.make().unarchive)
-        .mapZIO { case (archiveEntry, contentStream) =>
-          for {
-            content <- contentStream.runCollect
-            _ <- Console.printLine(s"${archiveEntry.name} ${content.length}")
-          } yield ()
-        }
-        .runDrain
+             .fromFileName("file.tgz")
+             .via(GzipDecompressor.decompress)
+             .via(TarUnarchiver.unarchive)
+             .mapZIO { case (archiveEntry, contentStream) =>
+               for {
+                 content <- contentStream.runCollect
+                 _ <- Console.printLine(s"${archiveEntry.name} ${content.length}")
+               } yield ()
+             }
+             .runDrain
 
-      // Create a ZIP archive (use the zip4j version for password support)
+      // Create an encrypted ZIP archive
       _ <- ZStream(archiveEntry("file1.txt", "Hello world!".getBytes(UTF_8)))
-        .via(ZipArchiver.make().archive)
-        .run(ZSink.fromFileName("file.zip"))
+             .via(Zip4JArchiver(password = Some("it is a secret")).archive)
+             .run(ZSink.fromFileName("file.zip"))
     } yield ()
 
   private def archiveEntry(
-                            name: String,
-                            content: Array[Byte]
-                          ): (ArchiveEntry[Some, Any], ZStream[Any, Throwable, Byte]) = {
-    (ArchiveEntry(name, Some(content.length)), ZStream.fromIterable(content))
-  }
+    name: String,
+    content: Array[Byte],
+  ): (ArchiveEntry[Some, Any], ZStream[Any, Throwable, Byte]) =
+    (ArchiveEntry(name, Some(content.length.toLong)), ZStream.fromIterable(content))
+
 }
 ```
 

--- a/gzip/src/main/scala/zio/compress/Gzip.scala
+++ b/gzip/src/main/scala/zio/compress/Gzip.scala
@@ -32,7 +32,6 @@ final class GzipCompressor private (
   bufferSize: Int,
 ) extends Compressor {
 
-  /** @inheritdoc */
   override def compress(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Byte] =
     ZPipeline.gzip(
       bufferSize,
@@ -57,7 +56,6 @@ object GzipDecompressor {
 
 final class GzipDecompressor private (bufferSize: Int) extends Decompressor {
 
-  /** @inheritdoc */
   override def decompress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     ZPipeline.gunzip(bufferSize)
 }

--- a/gzip/src/test/scala/zio/compress/GzipSpec.scala
+++ b/gzip/src/test/scala/zio/compress/GzipSpec.scala
@@ -19,7 +19,7 @@ object GzipSpec extends ZIOSpecDefault {
         for {
           obtained <- ZStream
                         .fromChunk(compressed)
-                        .via(GzipDecompressor.make().decompress)
+                        .via(GzipDecompressor.decompress)
                         .runCollect
         } yield assertTrue(clear == obtained)
       },
@@ -29,8 +29,8 @@ object GzipSpec extends ZIOSpecDefault {
             obtained <- ZStream
                           .fromChunk(genBytes)
                           .rechunk(chunkSize)
-                          .via(GzipCompressor.make().compress)
-                          .via(GzipDecompressor.make().decompress)
+                          .via(GzipCompressor.compress)
+                          .via(GzipDecompressor.decompress)
                           .runCollect
           } yield assertTrue(obtained == genBytes)
         }

--- a/lz4/src/main/scala/zio/compress/Lz4.scala
+++ b/lz4/src/main/scala/zio/compress/Lz4.scala
@@ -26,7 +26,6 @@ object Lz4Compressor {
 
 final class Lz4Compressor private (blockSize: Lz4CompressorBlockSize) extends Compressor {
 
-  /** @inheritdoc */
   override def compress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] = {
     val lz4BlockSize = blockSize match {
       case Lz4CompressorBlockSize.BlockSize64KiB  => BLOCKSIZE.SIZE_64KB
@@ -54,7 +53,6 @@ object Lz4Decompressor {
 
 final class Lz4Decompressor private (chunkSize: Int) extends Decompressor {
 
-  /** @inheritdoc */
   override def decompress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     // LZ4FrameInputStream.read does not try to read the requested number of bytes, but it does have a good
     // `available()` implementation, so with buffering we can still get full chunks.

--- a/lz4/src/main/scala/zio/compress/Lz4.scala
+++ b/lz4/src/main/scala/zio/compress/Lz4.scala
@@ -10,18 +10,23 @@ import java.io.BufferedInputStream
 
 object Lz4Compressor {
 
-  /** Make a pipeline that accepts a stream of bytes and produces a stream with Lz4 compressed bytes.
+  /** A [[Compressor]] for LZ4, based on official LZ4 java library.
     *
     * @param blockSize
     *   the block size to use. Defaults to 256KiB.
     */
-  def make(
+  def apply(
     blockSize: Lz4CompressorBlockSize = Lz4CompressorBlockSize.BlockSize256KiB
   ): Lz4Compressor =
     new Lz4Compressor(blockSize)
+
+  /** See [[apply]] and [[Compressor.compress]]. */
+  def compress: ZPipeline[Any, Throwable, Byte, Byte] = apply().compress
 }
 
 final class Lz4Compressor private (blockSize: Lz4CompressorBlockSize) extends Compressor {
+
+  /** @inheritdoc */
   override def compress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] = {
     val lz4BlockSize = blockSize match {
       case Lz4CompressorBlockSize.BlockSize64KiB  => BLOCKSIZE.SIZE_64KB
@@ -35,16 +40,21 @@ final class Lz4Compressor private (blockSize: Lz4CompressorBlockSize) extends Co
 
 object Lz4Decompressor {
 
-  /** Makes a pipeline that accepts a Lz4 compressed byte stream and produces a decompressed byte stream.
+  /** A [[Decompressor]] for LZ4, based on official LZ4 java library.
     *
     * @param chunkSize
     *   The maximum chunk size of the outgoing ZStream. Defaults to `ZStream.DefaultChunkSize` (4KiB).
     */
-  def make(chunkSize: Int = ZStream.DefaultChunkSize): Lz4Decompressor =
+  def apply(chunkSize: Int = ZStream.DefaultChunkSize): Lz4Decompressor =
     new Lz4Decompressor(chunkSize)
+
+  /** See [[apply]] and [[Decompressor.decompress]]. */
+  def decompress: ZPipeline[Any, Throwable, Byte, Byte] = apply().decompress
 }
 
 final class Lz4Decompressor private (chunkSize: Int) extends Decompressor {
+
+  /** @inheritdoc */
   override def decompress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     // LZ4FrameInputStream.read does not try to read the requested number of bytes, but it does have a good
     // `available()` implementation, so with buffering we can still get full chunks.

--- a/lz4/src/test/scala/zio/compress/Lz4Spec.scala
+++ b/lz4/src/test/scala/zio/compress/Lz4Spec.scala
@@ -19,7 +19,7 @@ object Lz4Spec extends ZIOSpecDefault {
         for {
           obtained <- ZStream
                         .fromChunk(compressed)
-                        .via(Lz4Decompressor.make().decompress)
+                        .via(Lz4Decompressor.decompress)
                         .runCollect
         } yield assertTrue(clear == obtained)
       },
@@ -29,8 +29,8 @@ object Lz4Spec extends ZIOSpecDefault {
             obtained <- ZStream
                           .fromChunk(genBytes)
                           .rechunk(chunkSize)
-                          .via(Lz4Compressor.make().compress)
-                          .via(Lz4Decompressor.make().decompress)
+                          .via(Lz4Compressor.compress)
+                          .via(Lz4Decompressor.decompress)
                           .runCollect
           } yield assertTrue(obtained == genBytes)
         }

--- a/tar/src/main/scala/zio/compress/Tar.scala
+++ b/tar/src/main/scala/zio/compress/Tar.scala
@@ -14,14 +14,21 @@ import java.nio.file.attribute.FileTime
 
 object TarArchiver {
 
-  /** Makes a pipeline that accepts a stream of archive entries (with size), and produces a byte stream of a Tar
-    * archive.
+  /** An [[Archiver]] for Tar, based on the Apache Commons Compress library.
+    *
+    * The archive entries require the uncompressed size.
     */
-  def make(): TarArchiver =
+  def apply(): TarArchiver =
     new TarArchiver()
+
+  /** See [[apply]] and [[Archiver.archive]]. */
+  def archive: ZPipeline[Any, Throwable, (ArchiveEntry[Some, Any], ZStream[Any, Throwable, Byte]), Byte] =
+    apply().archive
 }
 
 final class TarArchiver private extends Archiver[Some] {
+
+  /** @inheritdoc */
   override def archive(implicit
     trace: Trace
   ): ZPipeline[Any, Throwable, (ArchiveEntry[Some, Any], ZStream[Any, Throwable, Byte]), Byte] =
@@ -40,16 +47,25 @@ final class TarArchiver private extends Archiver[Some] {
 
 object TarUnarchiver {
 
-  /** Makes a pipeline that accepts a byte stream of a Tar archive, and produces a stream of archive entries.
+  /** An [[Unarchiver]] for Tar, based on the Apache Commons Compress library.
+    *
+    * The archive entries might have a known uncompressed size.
     *
     * @param chunkSize
     *   chunkSize of the archive entry content streams. Defaults to 64KiB.
     */
-  def make(chunkSize: Int = Defaults.DefaultChunkSize): TarUnarchiver =
+  def apply(chunkSize: Int = Defaults.DefaultChunkSize): TarUnarchiver =
     new TarUnarchiver(chunkSize)
+
+  /** See [[apply]] and [[Unarchiver.unarchive]]. */
+  def unarchive
+    : ZPipeline[Any, Throwable, Byte, (ArchiveEntry[Option, TarArchiveEntry], ZStream[Any, IOException, Byte])] =
+    apply().unarchive
 }
 
 final class TarUnarchiver private (chunkSize: Int) extends Unarchiver[Option, TarArchiveEntry] {
+
+  /** @inheritdoc */
   override def unarchive(implicit
     trace: Trace
   ): ZPipeline[Any, Throwable, Byte, (ArchiveEntry[Option, TarArchiveEntry], ZStream[Any, IOException, Byte])] =

--- a/tar/src/main/scala/zio/compress/Tar.scala
+++ b/tar/src/main/scala/zio/compress/Tar.scala
@@ -28,7 +28,6 @@ object TarArchiver {
 
 final class TarArchiver private extends Archiver[Some] {
 
-  /** @inheritdoc */
   override def archive(implicit
     trace: Trace
   ): ZPipeline[Any, Throwable, (ArchiveEntry[Some, Any], ZStream[Any, Throwable, Byte]), Byte] =
@@ -65,7 +64,6 @@ object TarUnarchiver {
 
 final class TarUnarchiver private (chunkSize: Int) extends Unarchiver[Option, TarArchiveEntry] {
 
-  /** @inheritdoc */
   override def unarchive(implicit
     trace: Trace
   ): ZPipeline[Any, Throwable, Byte, (ArchiveEntry[Option, TarArchiveEntry], ZStream[Any, IOException, Byte])] =

--- a/tar/src/test/scala/zio/compress/TarSpec.scala
+++ b/tar/src/test/scala/zio/compress/TarSpec.scala
@@ -39,8 +39,8 @@ object TarSpec extends ZIOSpecDefault {
         for {
           obtained <- ZStream
                         .fromChunk(tgzArchive)
-                        .via(GzipDecompressor.make().decompress)
-                        .via(TarUnarchiver.make().unarchive)
+                        .via(GzipDecompressor.decompress)
+                        .via(TarUnarchiver.unarchive)
                         .mapZIO { case (archiveEntry, stream) =>
                           for {
                             content <- stream.runCollect
@@ -60,8 +60,8 @@ object TarSpec extends ZIOSpecDefault {
               ZStream
                 .fromChunk(genBytes)
                 .rechunk(chunkSize)
-                .via(ArchiveSingleFileCompressor.forName(TarArchiver.make(), "test", genBytes.length.toLong).compress)
-                .via(ArchiveSingleFileDecompressor(TarUnarchiver.make()).decompress)
+                .via(ArchiveSingleFileCompressor.forName(TarArchiver(), "test", genBytes.length.toLong).compress)
+                .via(ArchiveSingleFileDecompressor(TarUnarchiver()).decompress)
                 .runCollect
           } yield assertTrue(obtained == genBytes)
         }
@@ -72,7 +72,7 @@ object TarSpec extends ZIOSpecDefault {
                         archiveEntry("file1.txt", 12, "Hello world!"),
                         archiveEntry("subdir/file2.txt", 999999, "Hello from subdir!"),
                       )
-                        .via(TarArchiver.make().archive)
+                        .via(TarArchiver.archive)
                         .runCollect
                         .exit
         } yield
@@ -94,8 +94,8 @@ object TarSpec extends ZIOSpecDefault {
       //            archiveEntry("file1.txt", 12, "Hello world!"),
       //            archiveEntry("subdir/file2.txt", 18, "Hello from subdir!")
       //          )
-      //            .via(TarArchiver.make().archive)
-      //            .via(GzipCompressor.make().compress)
+      //            .via(TarArchiver.archive)
+      //            .via(GzipCompressor.compress)
       //            .runCollect
       //        } yield {
       //          println(Base64.getEncoder.encodeToString(obtained.toArray))

--- a/zip/src/main/scala/zio/compress/Zip.scala
+++ b/zip/src/main/scala/zio/compress/Zip.scala
@@ -37,7 +37,6 @@ final class ZipArchiver private (
   zipMethod: Option[ZipMethod],
 ) extends Archiver[Option] {
 
-  /** @inheritdoc */
   override def archive(implicit
     trace: Trace
   ): ZPipeline[Any, Throwable, (ArchiveEntry[Option, Any], ZStream[Any, Throwable, Byte]), Byte] =
@@ -82,7 +81,6 @@ object ZipUnarchiver {
 
 final class ZipUnarchiver private (chunkSize: Int) extends Unarchiver[Option, ZipEntry] {
 
-  /** @inheritdoc */
   override def unarchive(implicit
     trace: Trace
   ): ZPipeline[Any, Throwable, Byte, (ArchiveEntry[Option, ZipEntry], ZStream[Any, IOException, Byte])] =

--- a/zip/src/test/scala/zio/compress/ZipSpec.scala
+++ b/zip/src/test/scala/zio/compress/ZipSpec.scala
@@ -42,7 +42,7 @@ object ZipSpec extends ZIOSpecDefault {
         for {
           obtained <- ZStream
                         .fromChunk(zipArchive)
-                        .via(ZipUnarchiver.make().unarchive)
+                        .via(ZipUnarchiver.unarchive)
                         .mapZIO { case (archiveEntry, stream) =>
                           for {
                             content <- stream.runCollect
@@ -62,8 +62,8 @@ object ZipSpec extends ZIOSpecDefault {
               ZStream
                 .fromChunk(genBytes)
                 .rechunk(chunkSize)
-                .via(ArchiveSingleFileCompressor.forName(ZipArchiver.make(), "test", genBytes.length.toLong).compress)
-                .via(ArchiveSingleFileDecompressor(ZipUnarchiver.make()).decompress)
+                .via(ArchiveSingleFileCompressor.forName(ZipArchiver(), "test", genBytes.length.toLong).compress)
+                .via(ArchiveSingleFileDecompressor(ZipUnarchiver()).decompress)
                 .runCollect
           } yield assertTrue(obtained == genBytes)
         }
@@ -72,8 +72,8 @@ object ZipSpec extends ZIOSpecDefault {
         for {
           obtained <-
             ZStream(archiveEntry("readme.txt", "Hello world!"))
-              .via(ZipArchiver.make().archive)
-              .via(ZipUnarchiver.make().unarchive)
+              .via(ZipArchiver.archive)
+              .via(ZipUnarchiver.unarchive)
               .runCollect
         } yield assertTrue(obtained.head._1.name == "readme.txt")
       },

--- a/zip4j/src/main/scala/zio/compress/Zip4J.scala
+++ b/zip4j/src/main/scala/zio/compress/Zip4J.scala
@@ -32,7 +32,6 @@ object Zip4JArchiver {
 
 final class Zip4JArchiver private (password: => Option[String]) extends Archiver[Some] {
 
-  /** @inheritdoc */
   override def archive(implicit
     trace: Trace
   ): ZPipeline[Any, Throwable, (ArchiveEntry[Some, Any], ZStream[Any, Throwable, Byte]), Byte] =
@@ -77,7 +76,6 @@ object Zip4JUnarchiver {
 final class Zip4JUnarchiver private (password: Option[String], chunkSize: Int)
     extends Unarchiver[Option, LocalFileHeader] {
 
-  /** @inheritdoc */
   override def unarchive(implicit
     trace: Trace
   ): ZPipeline[Any, Throwable, Byte, (ArchiveEntry[Option, LocalFileHeader], ZStream[Any, IOException, Byte])] =

--- a/zip4j/src/test/scala/zio/compress/Zip4JSpec.scala
+++ b/zip4j/src/test/scala/zio/compress/Zip4JSpec.scala
@@ -56,7 +56,7 @@ object Zip4JSpec extends ZIOSpecDefault {
         for {
           obtained <- ZStream
                         .fromChunk(zipArchive)
-                        .via(Zip4JUnarchiver.make().unarchive)
+                        .via(Zip4JUnarchiver.unarchive)
                         .mapZIO { case (archiveEntry, stream) =>
                           for {
                             content <- stream.runCollect
@@ -73,7 +73,7 @@ object Zip4JSpec extends ZIOSpecDefault {
         for {
           obtained <- ZStream
                         .fromChunk(encryptedZipArchive)
-                        .via(Zip4JUnarchiver.make(password = Some("secret")).unarchive)
+                        .via(Zip4JUnarchiver(password = Some("secret")).unarchive)
                         .mapZIO { case (archiveEntry, stream) =>
                           for {
                             content <- stream.runCollect
@@ -93,8 +93,8 @@ object Zip4JSpec extends ZIOSpecDefault {
               ZStream
                 .fromChunk(genBytes)
                 .rechunk(chunkSize)
-                .via(ArchiveSingleFileCompressor.forName(Zip4JArchiver.make(), "test", genBytes.length.toLong).compress)
-                .via(ArchiveSingleFileDecompressor(Zip4JUnarchiver.make()).decompress)
+                .via(ArchiveSingleFileCompressor.forName(Zip4JArchiver(), "test", genBytes.length.toLong).compress)
+                .via(ArchiveSingleFileDecompressor(Zip4JUnarchiver()).decompress)
                 .runCollect
           } yield assertTrue(obtained == genBytes)
         }
@@ -105,7 +105,7 @@ object Zip4JSpec extends ZIOSpecDefault {
                         archiveEntry("file1.txt", 12, "Hello world!"),
                         archiveEntry("subdir/file2.txt", 999999, "Hello from subdir!"),
                       )
-                        .via(Zip4JArchiver.make().archive)
+                        .via(Zip4JArchiver.archive)
                         .runCollect
                         .exit
         } yield

--- a/zstd/src/main/scala/zio/compress/Zstd.scala
+++ b/zstd/src/main/scala/zio/compress/Zstd.scala
@@ -37,7 +37,6 @@ final class ZstdCompressor private (
   customDictionary: Option[Array[Byte]],
 ) extends Compressor {
 
-  /** @inheritdoc */
   override def compress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     viaOutputStreamByte { outputStream =>
       val zstdOutputStream = new ZstdOutputStream(outputStream)
@@ -64,7 +63,6 @@ object ZstdDecompressor {
 
 final class ZstdDecompressor private (chunkSize: Int) extends Decompressor {
 
-  /** @inheritdoc */
   override def decompress(implicit trace: Trace): ZPipeline[Any, Throwable, Byte, Byte] =
     // ZstdInputStream.read does not try to read the requested number of bytes, but it does have a good
     // `available()` implementation, so with buffering we can still get full chunks.

--- a/zstd/src/test/scala/zio/compress/ZstdSpec.scala
+++ b/zstd/src/test/scala/zio/compress/ZstdSpec.scala
@@ -19,7 +19,7 @@ object ZstdSpec extends ZIOSpecDefault {
         for {
           obtained <- ZStream
                         .fromChunk(compressed)
-                        .via(ZstdDecompressor.make().decompress)
+                        .via(ZstdDecompressor.decompress)
                         .runCollect
         } yield assertTrue(clear == obtained)
       },
@@ -29,8 +29,8 @@ object ZstdSpec extends ZIOSpecDefault {
             obtained <- ZStream
                           .fromChunk(genBytes)
                           .rechunk(chunkSize)
-                          .via(ZstdCompressor.make().compress)
-                          .via(ZstdDecompressor.make().decompress)
+                          .via(ZstdCompressor.compress)
+                          .via(ZstdDecompressor.decompress)
                           .runCollect
           } yield assertTrue(obtained == genBytes)
         }


### PR DESCRIPTION
Cleans up the API, you no longer need to type `make`. For example:

 - `SomeCompressor.make().compress` --> `SomeCompressor.compress`
 - `SomeCompressor.make(parameter = value).compress` --> `SomeCompressor(parameter = value).compress`