### PR TITLE
Workflow updates, sbt-zio workaround

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   auto-approve:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@v4
         if: github.actor == 'scala-steward'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         distribution: corretto
         java-version: '17'
         check-latest: true
+    - name: Setup sbt
+      uses: sbt/setup-sbt@v1
     - name: Cache Dependencies
       uses: coursier/cache-action@v6
     - name: Check all code compiles
@@ -61,10 +63,12 @@ jobs:
         distribution: corretto
         java-version: '17'
         check-latest: true
+    - name: Setup sbt
+      uses: sbt/setup-sbt@v1
     - name: Cache Dependencies
       uses: coursier/cache-action@v6
-    - name: Check if the site workflow is up to date
-      run: sbt ciCheckGithubWorkflow
+#    - name: Check if the site workflow is up to date
+#      run: sbt ciCheckGithubWorkflow
     - name: Lint
       run: sbt lint
   test:
@@ -87,6 +91,8 @@ jobs:
         distribution: corretto
         java-version: ${{ matrix.java }}
         check-latest: true
+    - name: Setup sbt
+      uses: sbt/setup-sbt@v1
     - name: Cache Dependencies
       uses: coursier/cache-action@v6
     - name: Git Checkout
@@ -113,6 +119,8 @@ jobs:
         distribution: corretto
         java-version: '17'
         check-latest: true
+    - name: Setup sbt
+      uses: sbt/setup-sbt@v1
     - name: Cache Dependencies
       uses: coursier/cache-action@v6
     - name: Generate Readme
@@ -187,6 +195,8 @@ jobs:
         distribution: corretto
         java-version: '17'
         check-latest: true
+    - name: Setup sbt
+      uses: sbt/setup-sbt@v1
     - name: Cache Dependencies
       uses: coursier/cache-action@v6
     - name: Release
@@ -216,6 +226,8 @@ jobs:
         distribution: corretto
         java-version: '17'
         check-latest: true
+    - name: Setup sbt
+      uses: sbt/setup-sbt@v1
     - name: Cache Dependencies
       uses: coursier/cache-action@v6
     - name: Setup NodeJs

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6
         env:

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -6,14 +6,20 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch: {}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   scala-steward:
     timeout-minutes: 45
     runs-on: ubuntu-latest
     name: Scala Steward
     steps:
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
       - name: Scala Steward
-        uses: scala-steward-org/scala-steward-action@v2.71.0
+        uses: scala-steward-org/scala-steward-action@v2
         with:
           github-app-id: ${{ secrets.SCALA_STEWARD_GITHUB_APP_ID }}
           github-app-installation-id: ${{ secrets.SCALA_STEWARD_GITHUB_APP_INSTALLATION_ID }}


### PR DESCRIPTION
Sbt is no longer available on ubuntu-latest. Install it with an additional step. This is a stop-gap measure until sbt-zio is fixed.

Also:
 - use ubuntu-latest everywhere
 - update scala-steward workflow
 - disable ciCheckGithubWorkflow for now