### PR TITLE
Optimize decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ libraryDependencies += "dev.zio" %% "zio-streams-compress-zip4j" % "2.0.0"
 libraryDependencies += "dev.zio" %% "zio-streams-compress-zstd" % "2.0.0"
 ```
 
+_As of 2.2.0, zio-streams-compress requires zio 2.1.25 or later._
+
 For Brotli you can choose between the 'brotli' and the 'brotli4j' version. The first is based on the official Java
 library but only does decompression. The second is based on [Brotli4J](https://github.com/hyperxpro/Brotli4j) which does
 compression and decompression.

--- a/core/src/main/scala/zio/compress/JavaIoInterop.scala
+++ b/core/src/main/scala/zio/compress/JavaIoInterop.scala
@@ -38,7 +38,7 @@ private[compress] object JavaIoInterop {
     queueSize: Int = Defaults.DefaultChunkedQueueSize,
   )(makeInputStream: InputStream => InputStream): ZPipeline[Any, Throwable, Byte, Byte] =
     viaInputStream[Byte](queueSize) { inputStream =>
-      ZIO.attemptBlockingInterrupt(ZStream.fromInputStream(makeInputStream(inputStream), chunkSize))
+      ZIO.attempt(ZStream.fromInputStream(makeInputStream(inputStream), chunkSize))
     }
 
   /** Makes a pipeline that makes the incoming ZStream available for reading via an InputStream. This is then used by

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,8 @@ libraryDependencies += "dev.zio" %% "zio-streams-compress-zip4j" % "@VERSION@"
 libraryDependencies += "dev.zio" %% "zio-streams-compress-zstd" % "@VERSION@"
 ```
 
+_As of 2.2.0, zio-streams-compress requires zio 2.1.25 or later._
+
 For Brotli you can choose between the 'brotli' and the 'brotli4j' version. The first is based on the official Java
 library but only does decompression. The second is based on [Brotli4J](https://github.com/hyperxpro/Brotli4j) which does
 compression and decompression.


### PR DESCRIPTION
Since zio 2.1.25, `ZStream.fromInputStream` is interruptable, internally using `ZIO.attemptBlockingInterrupt` where needed, and using direct reads where possible (see https://github.com/zio/zio/pull/10512).

 As a consequence, we no longer need to wrap `ZStream.fromInputStream` in a `ZIO.attemptBlockingInterrupt`, instead we wrap it in the much more performant `ZIO.attempt`.

This should make all decoders faster.