### PR TITLE
fix(ci): prevent release job from running on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
     continue-on-error: false
     needs:
     - ci
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ (github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'workflow_dispatch' }}
     steps:
     - name: Git Checkout
       uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Fixed a condition bug in the CI workflow that was causing the release job to run on every push to main, leading to duplicate deployment attempts.

### The Problem

The release job had this condition:
```yaml
if: ${{ github.event_name != 'pull_request' }}
```

This was too permissive and caused the release job to execute on:
- ✓ `release` events (correct)
- ✓ `workflow_dispatch` (correct)  
- ✗ **`push` to main** (incorrect - this caused duplicates)

When a release was published after a push to main, the same version would be deployed twice, causing the "artifact already exists" error.

### The Solution

Changed the condition to explicitly check for release events with 'published' action:
```yaml
if: ${{ (github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'workflow_dispatch' }}
```

This matches the pattern already used in the `release-docs` job and ensures the release job only runs when intended.

### Fixes

- Resolves duplicate artifact deployment failures  
- Prevents redundant Maven Central publishing attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)